### PR TITLE
Use s3 prefix for configuration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* Use s3 prefix for configuration
+
 Version 0.2.0 - 2021-10-13
 * Fallback to boto3 authentication mechanisms 
 * Drop deprecated use_2to3 setuptools option 

--- a/README
+++ b/README
@@ -6,14 +6,14 @@ S3 AWS backend for the Tryton application framework.
 In order to configure the S3 Amazon you should modify your trytond
 configuration file to include the `tryton_filestore_s3.FileStoreS3` as class
 of the database section. Also you need to specify the s3 credentials
-with the access_key, secret_key and bucket values.
+with the s3_access_key, s3_secret_key and bucket values.
 
 An example configuration file looks like::
 
     [database]
     class=tryton_filestore_s3.FileStoreS3
-    access_key=access-key-s3
-    secret_key=secret-key-s3
+    s3_access_key=access-key-s3
+    s3_secret_key=secret-key-s3
     bucket=bucket-id-here
 
 Once you have specified the config file, everything should work out of the

--- a/tryton_filestore_s3.py
+++ b/tryton_filestore_s3.py
@@ -42,8 +42,12 @@ def name(id, prefix=''):
 
 
 def get_client():
-    access_key = config.get('database', 'access_key', default=None)
-    secret_key = config.get('database', 'secret_key', default=None)
+    access_key = config.get('database', 's3_access_key')
+    if access_key is None:
+        access_key = config.get('database', 'access_key')
+    secret_key = config.get('database', 's3_secret_key')
+    if secret_key is None:
+        secret_key = config.get('database', 'secret_key')
     bucket = config.get('database', 'bucket')
     client = boto3.client(
         's3',


### PR DESCRIPTION
I think this will avoid mistakes to reuse credentials of other filestore.